### PR TITLE
🏗️ Clean Architecture: Remove Search Logic Duplication

### DIFF
--- a/PokedexPocket/Features/PokemonList/Presentation/PokemonListViewModel.swift
+++ b/PokedexPocket/Features/PokemonList/Presentation/PokemonListViewModel.swift
@@ -105,12 +105,20 @@ class PokemonListViewModel: ObservableObject {
 
         isSearching = true
 
-        let filteredResults = allPokemon.filter { pokemon in
-            pokemon.name.lowercased().contains(query.lowercased())
-        }
-
-        pokemonList = filteredResults
-        isSearching = false
+        searchPokemonUseCase
+            .execute(query: query)
+            .observe(on: MainScheduler.instance)
+            .subscribe(
+                onNext: { [weak self] filteredResults in
+                    self?.pokemonList = filteredResults
+                    self?.isSearching = false
+                },
+                onError: { [weak self] error in
+                    self?.error = error
+                    self?.isSearching = false
+                }
+            )
+            .disposed(by: disposeBag)
     }
 
     func retry() {


### PR DESCRIPTION
## Summary
- Removed duplicate search implementation from PokemonListViewModel
- Updated ViewModel to use SearchPokemonUseCase exclusively  
- Consolidated search logic in Repository layer following Clean Architecture principles

## Changes
- **PokemonListViewModel.swift**: Replaced direct array filtering with proper UseCase usage
- Search functionality now flows through Repository → UseCase → ViewModel layers
- Maintained reactive RxSwift architecture and error handling

## Test Plan
- [x] Build completes successfully
- [x] Search functionality preserved with proper layer separation
- [x] Reactive data flow maintained

Closes #3